### PR TITLE
Replace bcrypt with argon2 to avoid 72-byte password limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🗓️ Timetable Management System (Backend + Frontend)
 
-A smart and automated **Timetable Management System** for engineering colleges, built using **FastAPI** for backend, **React** for frontend, and **PostgreSQL** for managing complex scheduling data.
+A smart and automated **Timetable Management System** for engineering colleges, built using **FastAPI** for backend, **Svelte** for frontend, and **PostgreSQL** for managing complex scheduling data.
 
 ---
 
@@ -29,7 +29,7 @@ Common issues include:
 - Admin dashboard APIs
 - Secure role-based access (Admin, Faculty)
 
-### 💻 Frontend (React)
+### 💻 Frontend (Svelte)
 - Clean, user-friendly dashboard for Admin and Faculty
 - Drag-and-drop timetable editor
 - Real-time views of schedule
@@ -43,7 +43,7 @@ Common issues include:
 
 | Layer       | Technology           |
 |-------------|----------------------|
-| Frontend    | **Svelt** |
+| Frontend    | **Svelte** |
 | Backend     | **FastAPI** (Python) |
 | Database    | **PostgreSQL** (Recommended) |
 | Containerization | **Docker**, Docker Compose |
@@ -114,6 +114,3 @@ docker-compose up -d
    Copy-Item .env.example .env
 
 Then, open the .env file and replace the dummy values with actual credentials 
-
-   
-& "C:\Program Files\Docker\Docker\resources\bin\docker.exe" compose build

--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ Adminer provides an easy-to-use UI to browse tables, run queries, and manage the
 1. Start all services:
    ```bash
    docker-compose up --build
+# Stop containers
+docker-compose down
 
+# Rebuild and start in detached mode
+docker-compose up --build -d
+
+# Or rebuild just the backend service
+docker-compose build backend
+docker-compose up -d
 2. Open Adminer in your browser:
     ```bash
     http://localhost:8080

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -3,7 +3,7 @@ from app.models.user import User
 from app.schemas.user import UserCreate
 from passlib.context import CryptContext
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
 
 def get_user_by_username(db: Session, username: str):
     statement = select(User).where(User.username == username)
@@ -11,6 +11,7 @@ def get_user_by_username(db: Session, username: str):
     return result
 
 def create_user(db: Session, user: UserCreate):
+    # Argon2 doesn't have the 72-byte limitation, so we can hash the full password
     hashed_password = pwd_context.hash(user.password)
     db_user = User(
         username=user.username,
@@ -23,6 +24,7 @@ def create_user(db: Session, user: UserCreate):
     return db_user
 
 def verify_password(plain_password, hashed_password):
+    # Argon2 can handle full password without truncation
     return pwd_context.verify(plain_password, hashed_password)
 def get_user_by_email(session: Session, email: str):
     statement = select(User).where(User.email == email)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -19,6 +19,7 @@ def register(user: UserCreate, session: Session = Depends(get_db)):
     if get_user_by_email(session, user.email):
         raise HTTPException(status_code=400, detail="Email already registered")
     return create_user(session, user)
+    
 
 @router.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends(), session: Session = Depends(get_db)):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary               # PostgreSQL driver
 python-dotenv                 # load .env variables
 pydantic>=2.0                 # Pydantic v2+
 pydantic-settings>=2.0        # for BaseSettings in v2
-passlib[bcrypt]              # password hashing
+passlib[argon2]              # password hashing
 python-jose[cryptography]    # JWT creation & verification
 email-validator
 python-multipart


### PR DESCRIPTION


- Replaced passlib[bcrypt] with passlib[argon2] to handle passwords longer than 72 bytes.
- Updated password hashing and verification functions.
- argon2 is more secure and does not have the old bcrypt limitation.