### PR TITLE
Include deleted user metadata in User DELETE API response

### DIFF
--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -3,7 +3,7 @@ from sqlmodel import Session, select
 from app.database import get_db
 from app.models.user import User
 from app.schemas.user import UserCreate, UserOut, UserUpdate
-from app.schemas.utils import Message
+from app.schemas.utils import DeleteResponse
 from app.crud.deps import get_current_user
 
 router = APIRouter()
@@ -36,7 +36,7 @@ def update_user(user_id: int, user: UserUpdate, session: Session = Depends(get_d
     session.refresh(db_user)
     return db_user
 
-@router.delete("/{user_id}", response_model=Message)
+@router.delete("/{user_id}", response_model=DeleteResponse)
 def delete_user(user_id: int, session: Session = Depends(get_db), current_user=Depends(get_current_user)):
     db_user = session.get(User, user_id)
     if not db_user:
@@ -44,4 +44,12 @@ def delete_user(user_id: int, session: Session = Depends(get_db), current_user=D
     
     session.delete(db_user)
     session.commit()
-    return Message(message="User deleted successfully")
+    return DeleteResponse(message="User deleted successfully",
+                          data={
+                              "id": db_user.id,
+                              "email": db_user.email,
+                              "username": db_user.username
+                          }
+    )
+    
+    

--- a/backend/app/schemas/utils.py
+++ b/backend/app/schemas/utils.py
@@ -2,3 +2,7 @@ from sqlmodel import SQLModel
 
 class Message(SQLModel):
     message: str
+    
+class DeleteResponse(SQLModel):
+    message: str
+    data: dict| None = None


### PR DESCRIPTION
This PR enhances the User DELETE API by returning basic metadata of the deleted user along with the success message.
Earlier, the endpoint returned only a generic success message, which made frontend confirmation and debugging harder.

With this change, the DELETE response now includes key identifiers of the deleted user while keeping the existing delete logic unchanged.

Updated User DELETE endpoint to return :
          id
          email
          username

Closes #80 