### PR TITLE
Department DELETE metadata

### DIFF
--- a/backend/app/routers/department.py
+++ b/backend/app/routers/department.py
@@ -55,12 +55,13 @@ def delete_department(department_id: int, db: Session = Depends(get_db), current
     existing = db.get(Department, department_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Department not found")
+    deleted_data = {
+                     "id" : existing.id,
+                     "name": existing.name,
+                     "year": existing.year                             
+                 }
     db.delete(existing)
     db.commit()
     return DeleteResponse(message="Department deleted successfully",
-                            data = {
-                                    "id" : existing.id,
-                                    "name": existing.name,
-                                    "year": existing.year
-                            }
+                          data=deleted_data
     )


### PR DESCRIPTION
This PR enhances the Department DELETE API by returning basic metadata of the deleted department along with the success message. Previously, the endpoint returned only a generic success message, which made it harder to confirm which department was removed.

With this update, the DELETE response now includes key department identifiers while keeping the existing delete logic unchanged.

Updated Department DELETE endpoint to return :
      id
      name
      year

Used the common delete response schema for consistent DELETE responses
Closes #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delete department endpoint now returns a richer confirmation: a user-facing message plus detailed data about the deleted department (ID, name, and year) for clearer feedback and verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->