### PR TITLE
Include deleted role metadata in Role DELETE API response

### DIFF
--- a/backend/app/schemas/role.py
+++ b/backend/app/schemas/role.py
@@ -8,4 +8,11 @@ class RoleRead(BaseModel):
     role_name: str
     
     class Config:
-        orm_mode = True
+        from_attributes = True
+    
+class DeleteRoleResponse(BaseModel):
+    message: str
+    data: RoleRead | None = None
+    
+    
+        


### PR DESCRIPTION
This PR enhances the Role DELETE API by returning basic metadata of the deleted role along with the success message. Earlier, the endpoint returned only a generic confirmation message, which made it harder to identify which role was removed.

The response now includes clear role identifiers while keeping the existing delete behavior unchanged.

closes #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role deletion endpoint now returns a structured response containing a message plus the deleted role's details (e.g., ID and name) on success.
  * Deletion still returns 404 if the role does not exist, improving clarity and traceability of deletion operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->