### PR TITLE
Include deleted classroom metadata in Classroom DELETE API response

### DIFF
--- a/backend/app/schemas/classroom.py
+++ b/backend/app/schemas/classroom.py
@@ -26,3 +26,7 @@ class ClassroomRead(SQLModel):
 
     class Config:
         from_attributes = True
+
+class DeleteClassroomResponse(SQLModel):
+    message: str
+    data: ClassroomRead| None = None


### PR DESCRIPTION
This PR enhances the Classroom DELETE API by returning meaningful metadata of the deleted classroom along with the success message. Previously, the endpoint returned only a generic confirmation, which made it harder to identify which classroom was removed.

With this update, the DELETE response now includes clear identifiers while keeping the existing delete logic unchanged.

Updated Classroom DELETE endpoint to return metadata :-
          id
          building_name
          classroom_no
          department_id

Close #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deletion endpoint now returns a structured confirmation that includes the deleted classroom’s public details (ID, building, number, department) rather than a plain message.

* **Improvements**
  * Delete responses are now delivered using a consistent, standardized response shape, aligning delete behavior with create/update/get endpoints for more reliable API feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->